### PR TITLE
修复ColumnType无法显示数据

### DIFF
--- a/src/ColumnType/CheckboxText/CheckboxText.php
+++ b/src/ColumnType/CheckboxText/CheckboxText.php
@@ -9,7 +9,7 @@ class CheckboxText extends ColumnType{
     public function build(array &$option, array $data, $listBuilder) : string{
         $component_option = $option['value'];
         $value = $data[$option['name']];
-        $value = json_decode($value, true);
+        $value = json_decode(htmlspecialchars_decode($value), true);
         $show_data = [];
 
         foreach($component_option as $v){


### PR DESCRIPTION
json_decode的数据是html原始数据，无法解析。导致没有数据展示。现加上htmlspecialchars_decode修复。